### PR TITLE
Allow workflows to run for fork PRs

### DIFF
--- a/.github/workflows/build_GRmaps.yml
+++ b/.github/workflows/build_GRmaps.yml
@@ -17,8 +17,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Safety: don't run on forks
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/build_topskymaps.yml
+++ b/.github/workflows/build_topskymaps.yml
@@ -17,8 +17,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Safety: don't run on forks
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
Remove the security guard that prevented CI from running on pull requests originating from forked repositories. Deleted the comment and the `if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}` lines in .github/workflows/build_GRmaps.yml and .github/workflows/build_topskymaps.yml so the build jobs will run for forked-PRs.